### PR TITLE
Feature/UM-17-tile profiles

### DIFF
--- a/src/components/Card.jsx
+++ b/src/components/Card.jsx
@@ -18,11 +18,11 @@ const Card = (props) => {
     <form className=" w-full m-auto max-w-lg mt-2 relative">
   <label className="label">
     
-    <span className="label-text-alt flex items-start">Search for Resources</span>
+    <span className="label-text-alt flex items-start text-[#0A2E50] font-bold">Search for Resources</span>
   </label>
   <div className='relative'>
 
-  <input type="text" placeholder="Who can we help you find" className="input input-bordered w-[1200px] p-4 rounded-xl max-w-lg flex items-center font-bold text-black" />
+  <input type="text" placeholder="Who can we help you find" className="input input-bordered w-[1200px] p-4 rounded-xl max-w-lg flex items-center font-bold text-[#0A2E50]" />
   <button className='absolute right-1 top-1/2 -translate-y-1/2 p-4 '>
   <svg className="w-4 h-4 text-black-500 dark:text-black-400" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 20 20">
                 <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m19 19-4-4m0-7A7 7 0 1 1 1 8a7 7 0 0 1 14 0Z"/>
@@ -33,13 +33,13 @@ const Card = (props) => {
 </form>
 <div className='flex items-center justify-center mt-4 m-auto'>
 
-<button  className="bg-blue-100 text-blue-800 text-xs font-medium mr-2 px-2.5 py-0.5 rounded dark:bg-gray-700 dark:text-blue-400 border border-blue-400 p-3">LGBTQ+</button>
-<button  className="bg-gray-100 text-gray-800 text-xs font-medium mr-2 px-2.5 py-0.5 rounded dark:bg-gray-700 dark:text-gray-400 border border-gray-500 p-3">WOMEN</button>
-<button  className="bg-red-100 text-red-800 text-xs font-medium mr-2 px-2.5 py-0.5 rounded dark:bg-gray-700 dark:text-red-400 border border-red-400 p-3">BLACK</button>
-<button  className="bg-green-100 text-green-800 text-xs font-medium mr-2 px-2.5 py-0.5 rounded dark:bg-gray-700 dark:text-green-400 border border-green-400 p-3">ASIAN</button>
-<button  className="bg-yellow-100 text-yellow-800 text-xs font-medium mr-2 px-2.5 py-0.5 rounded dark:bg-gray-700 dark:text-yellow-300 border border-yellow-300 p-3">DISABILITY</button>
-<button  className="bg-purple-100 text-purple-800 text-xs font-medium mr-2 px-2.5 py-0.5 rounded dark:bg-gray-700 dark:text-purple-400 border border-purple-400 p-3">LATIN</button>
-<button  className="bg-pink-100 text-pink-800 text-xs font-medium mr-2 px-2.5 py-0.5 rounded dark:bg-gray-700 dark:text-pink-400 border border-pink-400 p-3">IMMIGRANT</button>
+<button  className="bg-white-100 text-[#0A2E50] text-xs font-medium mr-2 px-2.5 py-0.5 rounded-[20px] dark:bg-gray-700 dark:text-blue-400 border border-[#0A2E50] p-3">LGBTQ+</button>
+<button  className="bg-white-100 text-[#0A2E50] text-xs font-medium mr-2 px-2.5 py-0.5  rounded-[20px] dark:bg-gray-700 dark:text-gray-400 border border-[#0A2E50] p-3">WOMEN</button>
+<button  className="bg-white-100 text-[#0A2E50] text-xs font-medium mr-2 px-2.5 py-0.5  rounded-[20px] dark:bg-gray-700 dark:text-red-400 border border-[#0A2E50] p-3">BLACK</button>
+<button  className="bg-white-100 text-[#0A2E50] text-xs font-medium mr-2 px-2.5 py-0.5  rounded-[20px] dark:bg-gray-700 dark:text-green-400 border border-[#0A2E50] p-3">ASIAN</button>
+<button  className="bg-yewhite-100 text-[#0A2E50] text-xs font-medium mr-2 px-2.5 py-0.5  rounded-[20px] dark:bg-gray-700 dark:text-yellow-300 border border-[#0A2E50] p-3">DISABILITY</button>
+<button  className="bg-white-100 text-[#0A2E50] text-xs font-medium mr-2 px-2.5 py-0.5  rounded-[20px] dark:bg-gray-700 dark:text-purple-400 border border-[#0A2E50] p-3">LATIN</button>
+<button  className="bg-white-100 text-[#0A2E50] text-xs font-medium mr-2 px-2.5 py-0.5  rounded-[20px] dark:bg-gray-700 dark:text-pink-400 border border-[#0A2E50] p-3">IMMIGRANT</button>
 
 </div>
     <div className="w-full py-[10rem] px-4 bg-white ">

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,12 +1,28 @@
 // LIBRARY IMPORTS
 import React from 'react';
+import { NavLink } from 'react-router-dom';
 
 // LOCAL IMPORTS
 
 export default function NavBar() {
   return (
-    <div>
-      Navigation Bar will go here.
+    <div className="space-x-4">
+      <NavLink
+      exact
+      to="/"
+      className="px-4 py-2 bg-base-100 text-primary rounded-full font-bold hover:bg-red-500 hover:text-white"
+      activeClassName="bg-red-500 text-white border-red-500"
+      >
+        About Us
+      </NavLink>
+      <NavLink
+      to="/professionals"
+      className="px-4 py-2 bg-base-100 text-primary rounded-full font-bold hover:bg-red-500 hover:text-white"
+      activeClassName="bg-red-500 text-white border-red-500"
+      >
+        Resources
+      </NavLink>
     </div>
   )
 };
+

--- a/src/views/Layout.jsx
+++ b/src/views/Layout.jsx
@@ -3,28 +3,21 @@ import React from 'react';
 import { Outlet, Link } from 'react-router-dom';
 
 // LOCAL IMPORTS
-import NavBar from '../components/NavBar.jsx';
+import NavBar from '../components/Navbar';
 import logo from '../assets/logo.png';
+
 
 export function Layout() {
   return (
     <div className="flex flex-col w-full h-full min-h-screen">
-      <div className="p-4 w-full border-b-4 border-accent">
+      <div className="p-4 w-full">
         <div className="flex justify-between items-center mx-auto">
-          {/* Logo */}
           <div className="flex-shrink-0">
-            <img src={logo} alt="Your Logo" className="h-10" />
+            <Link to="/">
+              <img src={logo} alt="Your Logo" className="h-10" />
+            </Link>
           </div>
-
-          {/* Navigation */}
-          <div className="space-x-4">
-            <span className='font-bold pr-4'>About Us</span>
-              <Link to="/professionals">
-            <button className="btn btn-secondary p-2 rounded-lg font-bold">
-              Resources
-              </button>
-              </Link>
-          </div>
+          <NavBar/>
         </div>
       </div>
       <main className="flex-1 flex flex-col w-full">


### PR DESCRIPTION
## Description

<!-- 
Please do not leave this blank 
This PR creates a tiles display of all professionals from the BioData.js page.
There is a searchbar added but this is not functional.
-->

## Related Tickets & Documents
<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->

## Acceptance Criteria

- [x]  Profiles are displayed in a grid format on the "Discover Resources" page.

- [x] Each profile card displays the individual's photo, name, title, and a brief bio.

- [x] Profile cards are consistent in size and layout, ensuring a visually cohesive browsing experience.

- [x] Hovering over a profile card gives a subtle visual indication (e.g., shadow, border change).

- [ ] Clicking on a profile card navigates to the individual's detailed "Bio Display Page".

- [x] The grid dynamically adjusts to the screen size, ensuring responsiveness and optimal use of screen real estate on various devices.

<!-- Put an `x` between the brackets to mark complete (don't add spaces) e.g. -[x] -->
<!-- Include AC from the JIRA ticket https://lemon-zest.atlassian.net/jira/software/projects/UM/boards/2 -->

## What type of PR is this? (check all applicable)
<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|    x | :sparkles: New feature     |
|     | 🎨 Style                   |
|     | :hammer: Refactoring       |
|     | 🔥 Performance Improvements|
|    x | :bug: Bug fix              |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |


## Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

## What I learned
Images gotten from the web 
<img width="1680" alt="Screenshot 2023-10-29 at 9 16 05 AM" src="https://github.com/cherryontech/unmatched/assets/110904882/e372b111-b19d-4584-80cb-500297f77dcc">
have tendency  to give inconsistent sizing of already designed layout. Refactoring is necessary

## Testing steps
Switch to this branch with the following command: git switch feature/tile-profiles
Install dependencies with the following command: npm i
Run the following scripts: npm run dev to start Vite's dev build & npm run tailwind to start the Tailwind CSS build
View the app in browser (the npm run dev script will return the url you can see the app at)
View the page on full screen and reduced screen width.  Hover on each card to see the enlarged hover effect.
Interact with the code and ask questions/make suggestions - especially with tips to help out with the missing acceptance criteria.



## Added to documentation?
<!-- Put an `✓` for the applicable box: -->
|     | Type                       |
| --- | -------------------------- |
|     | 📜 README.md    |
|  x   | 🙅 no documentation needed    |


## What gif best describes this PR or how it makes you feel?
<!-- 
  to easily include a gif, go to giphy.com, copy the gif link (must be a gif, not a clip/video),
  and then insert it following this format:
  ![gif name](url) 
  the name you choose is arbitrary as it won't show up,
  but be sure to include the exclamation mark, brackets, and parentheses
-->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
