### PR TITLE
feature: bio pages route to top of page vs middle

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,16 +5,17 @@ import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 // LOCAL IMPORTS
 import { bioData } from './assets/bioData.js';
 import { Home, Layout, ProfessionalsPage, BioPage } from './views';
+import ScrollToTop from './components/ScrollToTop.jsx';
 
 function App() {
      // SET STATES
    const [data, setData] = useState(bioData);
-    
+
    const getFilteredCards = (tag) =>{
    const newData =bioData.filter((item)=> {
 
     return item.tags.includes(tag.toUpperCase());
-    
+
    });
   let sameData = true;
   for( let item of data){
@@ -26,7 +27,7 @@ function App() {
       setData(newData)
     }
     else{
-      
+
     setData(bioData)
     }
     }
@@ -37,6 +38,7 @@ function App() {
   return (
 
     <Router>
+      <ScrollToTop />
       <Routes>
         <Route path="/" element={<Layout />}>
           <Route index element={<Home />} />

--- a/src/components/ScrollToTop.jsx
+++ b/src/components/ScrollToTop.jsx
@@ -1,0 +1,13 @@
+// LIBRARY IMPORTS
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+
+export default function ScrollToTop() {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+}


### PR DESCRIPTION
## Description
The bio pages, when routed to from the resources page, were directing to the middle of the page vs the top. This PR fixes this by adding a new feature that supports scroll to top.
<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

## Related Tickets & Documents
<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->

## Acceptance Criteria
<!-- Put an `x` between the brackets to mark complete (don't add spaces) e.g. -[x] -->
<!-- Include AC from the JIRA ticket https://lemon-zest.atlassian.net/jira/software/projects/UM/boards/2 -->

## What type of PR is this? (check all applicable)
<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
| ✓  | :sparkles: New feature     |
|     | 🎨 Style                   |
|     | :hammer: Refactoring       |
|     | 🔥 Performance Improvements|
|  ✓ | :bug: Bug fix              |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |


## Mobile & Desktop Screenshots/Recordings
Before:
https://github.com/cherryontech/unmatched/assets/115492619/aaf4f08f-1d58-40f5-a2d9-7a5d2e571fe0

https://github.com/cherryontech/unmatched/assets/115492619/547b414f-5911-4eef-ba59-47b7433167fe




After:
https://github.com/cherryontech/unmatched/assets/115492619/7f4d35b1-5b21-4626-85f8-391ddd753398

https://github.com/cherryontech/unmatched/assets/115492619/7536e6fb-c6e2-492b-8744-44d3aff1ecc4




<!-- Visual changes require screenshots -->

## What I learned
In a single-page application (SPA) like those often built with React, when you navigate between pages using React Router, the page doesn't automatically scroll to the top like it would in a traditional multi-page website. This is because the page isn't fully reloaded; instead, components are just being swapped in and out within the same page.

## Testing steps
1. Switch to this branch with the following command: `git switch feature/route-to-top`
2. Run the following scripts: `npm run dev` to start Vite's dev build & `npm run tailwind` to start the Tailwind CSS build
3. View the app in browser (the `npm run dev` script will return the url you can see the app at)
4. Navigate to the the Resources page and then to several bio pages. 
5. On each bio page, ensure that you're routed to the top of the page.


## Added to documentation?
<!-- Put an `✓` for the applicable box: -->
|     | Type                       |
| --- | -------------------------- |
|     | 📜 README.md    |
|  ✓  | 🙅 no documentation needed    |


## What gif best describes this PR or how it makes you feel?
  ![gif name](https://media.giphy.com/media/H5qyL9DSW0kmt22uJ2/giphy.gif) 
<!-- 
  to easily include a gif, go to giphy.com, copy the gif link (must be a gif, not a clip/video),
  and then insert it following this format:
  ![gif name](url) 
  the name you choose is arbitrary as it won't show up,
  but be sure to include the exclamation mark, brackets, and parentheses
-->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
