### PR TITLE
#UM-33: Home page responsiveness

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -18,7 +18,7 @@ const buttons = [
   { id: 9, name: 'Indigenous', clicked: false },
 ];
 function App() {
-//  SET FILTER TAGS STATE
+  //  SET FILTER TAGS STATE
   const [tags, setTags] = useState(buttons);
 
   const changeButtonColor = id => {
@@ -33,66 +33,78 @@ function App() {
     setTags(isClicked);
   };
 
-  const resetTags = ()=>{
-    setTags(buttons)
-  }
+  const resetTags = () => {
+    setTags(buttons);
+  };
 
-     // SET   DATA STATES
-   const [data, setData] = useState(bioData);
+  // SET   DATA STATES
+  const [data, setData] = useState(bioData);
 
-   const getFilteredCards = (tag) =>{
-   const newData =bioData.filter((item)=> {
+  const getFilteredCards = tag => {
+    const newData = bioData.filter(item => {
+      return item.tags.includes(tag.toUpperCase());
+    });
 
-    return item.tags.includes(tag.toUpperCase());
-
-   });
-
-  let sameData = true;
-  for( let item of data){
-    if (!(newData.includes(item))){
-       sameData = false;
+    let sameData = true;
+    for (let item of data) {
+      if (!newData.includes(item)) {
+        sameData = false;
+      }
     }
-  }
-  if (!sameData){
-      setData(newData)
-    }
-    else{
-
-    setData(bioData)
-    }
-    }
-
-
-  const clicked = {clickedVoiceIcon:false, clickedAboutIcon:false}
-  
-  // SET NAV ICON STATE
-    const [iconClick, seticonClick] = useState(clicked )
-  
-    const changeVoicesColor = ()=>{
-      const isClicked = {...clicked, clickedVoiceIcon:true}
-      seticonClick(isClicked);
-      
-    }
-  
-    const ChangeAboutIcon = () =>{
-      const isClicked = {...clicked, clickedAboutIcon:true}
-      seticonClick(isClicked);
-    }
-  const resetData = () =>{
+    if (!sameData) {
+      setData(newData);
+    } else {
       setData(bioData);
     }
+  };
+
+  const clicked = { clickedVoiceIcon: false, clickedAboutIcon: false };
+
+  // SET NAV ICON STATE
+  const [iconClick, seticonClick] = useState(clicked);
+
+  const changeVoicesColor = () => {
+    const isClicked = { ...clicked, clickedVoiceIcon: true };
+    seticonClick(isClicked);
+  };
+
+  const ChangeAboutIcon = () => {
+    const isClicked = { ...clicked, clickedAboutIcon: true };
+    seticonClick(isClicked);
+  };
+  const resetData = () => {
+    setData(bioData);
+  };
   // SET REFERENCES
   const fullDataSetRef = useRef(bioData);
-  
-  return (
 
+  return (
     <Router>
       <ScrollToTop />
       <Routes>
-        <Route path="/" element={<Layout changeVoicesColor = {changeVoicesColor } ChangeAboutIcon={ChangeAboutIcon} 
-        iconClick={iconClick} resetData={resetData} resetTags={resetTags}/>}>
-          <Route index element={<Home fullDataSet={fullDataSetRef.current} changeVoicesColor = {changeVoicesColor } resetData={resetData}
-          resetTags={resetTags}/>} />
+        <Route
+          path="/"
+          element={
+            <Layout
+              changeVoicesColor={changeVoicesColor}
+              ChangeAboutIcon={ChangeAboutIcon}
+              iconClick={iconClick}
+              resetData={resetData}
+              resetTags={resetTags}
+            />
+          }
+        >
+          <Route
+            index
+            element={
+              <Home
+                fullDataSet={fullDataSetRef.current}
+                changeVoicesColor={changeVoicesColor}
+                resetData={resetData}
+                resetTags={resetTags}
+              />
+            }
+          />
           <Route
             path="/professionals"
             element={

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,16 +1,26 @@
 const Footer = () => {
   return (
-    <div className="bg-primary mt-[6rem]">  <p className=" text-center text-lg text-white m-auto mt-2"> &copy; Unmatched </p>
-    <div className="flex justify-center">
-
-    <div className="mr-2 my-2"><svg xmlns="http://www.w3.org/2000/svg" fill="white" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-6 h-6">
-  <path strokeLinecap="round" strokeLinejoin="round" d="M21.75 6.75v10.5a2.25 2.25 0 01-2.25 2.25h-15a2.25 2.25 0 01-2.25-2.25V6.75m19.5 0A2.25 2.25 0 0019.5 4.5h-15a2.25 2.25 0 00-2.25 2.25m19.5 0v.243a2.25 2.25 0 01-1.07 1.916l-7.5 4.615a2.25 2.25 0 01-2.36 0L3.32 8.91a2.25 2.25 0 01-1.07-1.916V6.75" />
-</svg> </div><div className="text-white my-2">lemonzest.squad@gmail.com</div>
-
-
+    <div className="flex flex-col items-center bg-primary py-2">
+      <p className="text-center text-lg m-auto text-white">&copy; Unmatched</p>
+      <div className="flex space-x-2 justify-center">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="white"
+          viewBox="0 0 24 24"
+          strokeWidth={1.5}
+          stroke="currentColor"
+          className="w-6 h-6"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M21.75 6.75v10.5a2.25 2.25 0 01-2.25 2.25h-15a2.25 2.25 0 01-2.25-2.25V6.75m19.5 0A2.25 2.25 0 0019.5 4.5h-15a2.25 2.25 0 00-2.25 2.25m19.5 0v.243a2.25 2.25 0 01-1.07 1.916l-7.5 4.615a2.25 2.25 0 01-2.36 0L3.32 8.91a2.25 2.25 0 01-1.07-1.916V6.75"
+          />
+        </svg>
+        <p className="text-white">lemonzest.squad@gmail.com</p>
+      </div>
     </div>
-    
-    </div>
-  )
-}
-export default Footer
+  );
+};
+
+export default Footer;

--- a/src/components/HeroCarousel.jsx
+++ b/src/components/HeroCarousel.jsx
@@ -10,7 +10,7 @@ import Slide3 from './Slide3.jsx';
 
 const customTheme = {
   scrollContainer: {
-    base: 'relative flex h-full scroll-smooth',
+    base: 'flex h-full scroll-smooth',
     snap: 'snap-x',
   },
   control: {
@@ -34,7 +34,7 @@ export default function HeroCarousel({ scroll }) {
   };
 
   return (
-    <div className="xl:h-[33rem] lg:h-[30rem] md:h-[28rem] h-[25rem] max-h-screen w-full bg-primary">
+    <div className="xl:h-[33rem] lg:h-[30rem] md:h-[28rem] h-[25rem] w-full bg-primary">
       <Carousel
         theme={customTheme}
         slideInterval={8000}

--- a/src/components/HeroCarousel.jsx
+++ b/src/components/HeroCarousel.jsx
@@ -19,7 +19,7 @@ const customTheme = {
   },
   indicators: {
     active: {
-      off: 'hover:bg-primary bg-stone-300',
+      off: 'hover:bg-primary bg-stone-300 ease-in-out duration-300',
       on: 'bg-primary',
     },
     base: 'h-3 w-3 rounded-full',
@@ -34,7 +34,7 @@ export default function HeroCarousel({ scroll }) {
   };
 
   return (
-    <>
+    <div className="xl:h-[33rem] lg:h-[30rem] md:h-[28rem] h-[25rem] max-h-screen w-full bg-primary">
       <Carousel
         theme={customTheme}
         slideInterval={8000}
@@ -42,7 +42,7 @@ export default function HeroCarousel({ scroll }) {
         leftControl={
           activeControl !== 0 && (
             <ChevronLeftIcon
-              className="w-10 text-white"
+              className="w-10 text-white hidden lg:block"
               style={{ strokeWidth: 3 }}
             />
           )
@@ -50,7 +50,7 @@ export default function HeroCarousel({ scroll }) {
         rightControl={
           activeControl !== 2 && (
             <ChevronRightIcon
-              className="w-10 text-white"
+              className="w-10 text-white hidden lg:block"
               style={{ strokeWidth: 3 }}
             />
           )
@@ -60,6 +60,6 @@ export default function HeroCarousel({ scroll }) {
         <Slide2 scroll={scroll} />
         <Slide3 scroll={scroll} />
       </Carousel>
-    </>
+    </div>
   );
 }

--- a/src/components/HeroCarousel.jsx
+++ b/src/components/HeroCarousel.jsx
@@ -5,9 +5,9 @@ import { Carousel } from 'flowbite-react';
 import { ChevronRightIcon, ChevronLeftIcon } from '@heroicons/react/24/outline';
 
 // LOCAL IMPORTS
-import carousel1 from '../assets/images/home/carousel1.png';
-import carousel2 from '../assets/images/home/carousel2.png';
-import carousel3 from '../assets/images/home/carousel3.png';
+import Slide1 from './Slide1.jsx';
+import Slide2 from './Slide2.jsx';
+import Slide3 from './Slide3.jsx';
 
 export default function HeroCarousel({ scroll }) {
   return (
@@ -27,100 +27,9 @@ export default function HeroCarousel({ scroll }) {
           />
         }
       >
-        {/* Slide 1 */}
-        <div className="carousel-item relative">
-          <div className="hero h-[30rem] lg:h-[35rem] max-h-[100%] w-full  bg-primary">
-            <div className="hero-content flex-col lg:flex-row-reverse">
-              <img
-                src={carousel1}
-                className=" rounded-full mx-auto w-[44%] lg:w-[27%] h-[11rem] lg:h-[20rem] shadow-2xl"
-              />
-              <div className="h-[305px] w-[100%] lg:w-[50rem] md:justify-start justify-center lg:text-start text-center sm:h-fit">
-                <p className="lg:text-5xl py-1 text-white font-bold text-[25px] lg:text-[20px]]">
-                  End Imposter Syndrome
-                </p>
-                <p className="lg:py-3 py-1 text-white text-[16px] w-[97%] lg:text-2xl lg:w-[85%]">
-                  Every unique perspective adds value to the world of STEM.{' '}
-                </p>
-                <p className="lg:py-3 py-1 text-white text-[16px] w-[97%] lg:text-2xl lg:w-[85%]">
-                  Free yourself from not fitting in and pave the way for your
-                  STEM journey.{' '}
-                </p>
-                <div className="mt-[2rem]">
-                  <Link
-                    onClick={() => scroll()}
-                    className="bg-secondary rounded-full px-4 lg:py-2 p-1 overflow-hidden text-white lg:text-[20px] text-[15px] font-bold hover:bg-gradient-to-r from-red-500 to-purple-500"
-                  >
-                    Learn More
-                  </Link>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-        {/* Slide 2 */}
-        <div className="carousel-item relative w-full scroll-smooth">
-          <div className="hero  h-[30rem] lg:h-[35rem] max-h-[100%] bg-primary">
-            <div className="hero-content flex-col lg:flex-row-reverse">
-              <img
-                src={carousel2}
-                className="max-w-sm  mx-auto h-[12rem] w-[9rem] lg:w-[20%] lg:h-[25%] shadow-2xl"
-              />
-              <div className="h-[305px] w-[100%] md:justify-start  justify-center lg:text-start text-center lg:w-[50rem] sm:h-fit">
-                <p className="lg:text-5xl py-1 text-white font-bold text-[25px] lg:text-[20px]]">
-                  Your Story Matters
-                </p>
-                <p className="lg:py-3 py-1 text-white text-[16px] w-[97%] lg:text-2xl lg:w-[85%]">
-                  Your journey is unique, and every step is a victory.{' '}
-                </p>
-                <p className="lg:py-3 py-1 text-white text-[16px] w-[97%] lg:text-2xl lg:w-[85%]">
-                  Inspire your network with your Unmatched story.{' '}
-                </p>
-                <div className="mt-[2rem]">
-                  <Link
-                    onClick={() => scroll()}
-                    className="bg-secondary rounded-full px-4 lg:py-2 p-1 overflow-hidden text-white lg:text-[20px] text-[15px] font-bold hover:bg-gradient-to-r from-red-500 to-purple-500"
-                  >
-                    Learn More
-                  </Link>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-        {/* Slide 3 */}
-        <div className="carousel-item relative w-full scroll-smooth">
-          <div className="hero  h-[30rem] lg:h-[35rem] max-h-[100%] bg-primary">
-            <div className="hero-content flex-col lg:flex-row-reverse">
-              <img
-                src={carousel3}
-                className="max-w-sm  mx-auto w-[30%] h-[5rem] lg:h-[20rem] shadow-2xl"
-              />
-              <div className="h-[305px] w-[80%] lg:w-[50rem] sm:h-fit md:justify-start lg:text-start  justify-center text-center ">
-                <p className="lg:text-5xl py-1 text-white font-bold text-[25px] lg:text-[20px]]">
-                  Connect with STEM Voices
-                </p>
-                <p className="lg:py-1 py-0 text-white text-[16px] w-[97%] lg:text-[21px] lg:w-[85%]">
-                  Uncover stories of STEM leaders who’ve overcome imposter
-                  syndrome and fostered a more inclusive STEM community.{' '}
-                </p>
-                <p className="lg:py-1 py-0 text-white text-[16px] w-[97%] lg:text-[21px] lg:w-[85%]">
-                  {' '}
-                  Find strength and inspiration as you navigate your own STEM
-                  path.{' '}
-                </p>
-                <div className="mt-[2rem]">
-                  <Link
-                    onClick={() => scroll()}
-                    className="bg-secondary rounded-full px-4 lg:py-2 p-1 overflow-hidden text-white lg:text-[20px] text-[15px] font-bold hover:bg-gradient-to-r from-red-500 to-purple-500"
-                  >
-                    Learn More
-                  </Link>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
+        <Slide1 scroll = {scroll} />
+        <Slide2 scroll = {scroll} />
+        <Slide3 scroll = {scroll} />
       </Carousel>
     </div>
   );

--- a/src/components/HeroCarousel.jsx
+++ b/src/components/HeroCarousel.jsx
@@ -1,6 +1,5 @@
 // LIBRARY IMPORTS
-import React from 'react';
-import { Link } from 'react-router-dom';
+import React, { useState } from 'react';
 import { Carousel } from 'flowbite-react';
 import { ChevronRightIcon, ChevronLeftIcon } from '@heroicons/react/24/outline';
 
@@ -9,28 +8,58 @@ import Slide1 from './Slide1.jsx';
 import Slide2 from './Slide2.jsx';
 import Slide3 from './Slide3.jsx';
 
+const customTheme = {
+  scrollContainer: {
+    base: 'relative flex h-full scroll-smooth',
+    snap: 'snap-x',
+  },
+  control: {
+    base: '',
+    icon: '',
+  },
+  indicators: {
+    active: {
+      off: 'hover:bg-primary bg-stone-300',
+      on: 'bg-primary',
+    },
+    base: 'h-3 w-3 rounded-full',
+    wrapper: 'absolute -bottom-13 py-4 flex justify-center gap-3 w-full',
+  },
+};
+
 export default function HeroCarousel({ scroll }) {
+  const [activeControl, setActiveControl] = useState(0);
+  const handleSlideChange = index => {
+    setActiveControl(index);
+  };
+
   return (
-    <div className="carousel w-full scroll-smooth">
+    <>
       <Carousel
+        theme={customTheme}
         slideInterval={8000}
+        onSlideChange={handleSlideChange}
         leftControl={
-          <ChevronLeftIcon
-            className="w-10 text-white"
-            style={{ strokeWidth: 3 }}
-          />
+          activeControl !== 0 && (
+            <ChevronLeftIcon
+              className="w-10 text-white"
+              style={{ strokeWidth: 3 }}
+            />
+          )
         }
         rightControl={
-          <ChevronRightIcon
-            className="w-10 text-white"
-            style={{ strokeWidth: 3 }}
-          />
+          activeControl !== 2 && (
+            <ChevronRightIcon
+              className="w-10 text-white"
+              style={{ strokeWidth: 3 }}
+            />
+          )
         }
       >
-        <Slide1 scroll = {scroll} />
-        <Slide2 scroll = {scroll} />
-        <Slide3 scroll = {scroll} />
+        <Slide1 scroll={scroll} />
+        <Slide2 scroll={scroll} />
+        <Slide3 scroll={scroll} />
       </Carousel>
-    </div>
+    </>
   );
 }

--- a/src/components/Slide1.jsx
+++ b/src/components/Slide1.jsx
@@ -1,0 +1,58 @@
+// LIBRARY IMPORTS
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+// LOCAL IMPORTS
+import carousel1 from '../assets/images/home/carousel1.png';
+
+export default function Slide1({ scroll }) {
+  return (
+    <div className="carousel-item relative">
+      <div className="hero h-[30rem] lg:h-[35rem] md:h-[30rem] sm:h-[25rem] max-h-screen w-full bg-primary">
+        <div className="hero-content flex-col lg:flex-row items-center lg:items-start">
+          {/* Text Section */}
+          <div className="flex-1 px-4 lg:px-8 text-center lg:text-left">
+            <p className="text-3xl lg:text-5xl font-bold text-white mt-4 lg:mt-0">
+              End Imposter Syndrome
+            </p>
+            <p className="mt-4 text-white text-sm sm:text-base md:text-lg lg:text-xl">
+              Every unique perspective adds value to the world of STEM.{' '}
+            </p>
+            <p className="mt-2 mb-4 text-white text-sm sm:text-base md:text-lg lg:text-xl">
+              Free yourself from not fitting in and pave the way for your
+              STEM journey.{' '}
+            </p>
+            {/* Button for large screens */}
+            <div className="mt-[2rem] hidden lg:block">
+              <Link
+                onClick={() => scroll()}
+                className="bg-secondary rounded-full px-4 lg:py-2 p-1 overflow-hidden text-white lg:text-[20px] text-[15px] font-bold hover:bg-gradient-to-r from-red-500 to-purple-500"
+              >
+                Learn More
+              </Link>
+            </div>
+          </div>
+          {/* Image */}
+          <div className="flex-1 flex justify-center lg:justify-end">
+            <div className="lg:w-72 lg:h-72 md:w-52 md:h-52 sm:w-40 sm:h-40 w-40 h-40 rounded-full overflow-hidden">
+              <img
+                src={carousel1}
+                className="w-full h-full object-cover"
+                alt="Description"
+              />
+            </div>
+          </div>
+          {/* Button for small and medium screens */}
+          <div className="mt-[2rem] lg:hidden w-full text-center">
+            <Link
+              onClick={() => scroll()}
+              className="bg-secondary rounded-full px-4 py-2 text-white text-[20px] font-bold hover:bg-gradient-to-r from-red-500 to-purple-500"
+            >
+              Learn More
+            </Link>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/Slide1.jsx
+++ b/src/components/Slide1.jsx
@@ -7,52 +7,47 @@ import carousel1 from '../assets/images/home/carousel1.png';
 
 export default function Slide1({ scroll }) {
   return (
-    <div className="carousel-item relative">
-      <div className="hero h-[30rem] lg:h-[35rem] md:h-[30rem] sm:h-[25rem] max-h-screen w-full bg-primary">
-        <div className="hero-content flex-col lg:flex-row items-center lg:items-start">
-          {/* Text Section */}
-          <div className="flex-1 px-4 lg:px-8 text-center lg:text-left">
-            <p className="text-3xl lg:text-5xl font-bold text-white mt-4 lg:mt-0">
-              End Imposter Syndrome
+    <div className="relative flex items-center justify-center h-full bg-primary">
+      <div className="md:w-[70%] w-[90%] mx-auto flex flex-col lg:flex-row justify-center items-center xl:gap-16 lg:gap-10 gap-4 text-white">
+        <div className="flex flex-col gap-0 md:gap-5 justify-center text-center lg:text-left">
+          <h1 className="text-3xl md:text-4xl lg:text-5xl font-bold">
+            End Imposter Syndrome
+          </h1>
+          <div className="xl:text-2xl lg:text-xl lg:w-[85%] flex flex-col gap-1 lg:gap-4">
+            <p>Every unique perspective adds value to the world of STEM.</p>
+            <p>
+              Free yourself from not fitting in and pave the way for your STEM
+              journey.
             </p>
-            <p className="mt-4 text-white text-sm sm:text-base md:text-lg lg:text-xl">
-              Every unique perspective adds value to the world of STEM.{' '}
-            </p>
-            <p className="mt-2 mb-4 text-white text-sm sm:text-base md:text-lg lg:text-xl">
-              Free yourself from not fitting in and pave the way for your
-              STEM journey.{' '}
-            </p>
-            {/* Button for large screens */}
-            <div className="mt-[2rem] hidden lg:block">
-              <Link
-                onClick={() => scroll()}
-                className="bg-secondary rounded-full px-4 lg:py-2 p-1 overflow-hidden text-white lg:text-[20px] text-[15px] font-bold hover:bg-gradient-to-r from-red-500 to-purple-500"
-              >
-                Learn More
-              </Link>
-            </div>
           </div>
-          {/* Image */}
-          <div className="flex-1 flex justify-center lg:justify-end">
-            <div className="lg:w-72 lg:h-72 md:w-52 md:h-52 sm:w-40 sm:h-40 w-40 h-40 rounded-full overflow-hidden">
-              <img
-                src={carousel1}
-                className="w-full h-full object-cover"
-                alt="Description"
-              />
-            </div>
-          </div>
-          {/* Button for small and medium screens */}
-          <div className="mt-[2rem] lg:hidden w-full text-center">
+          {/* Button for large screens */}
+          <div className="hidden lg:block">
             <Link
               onClick={() => scroll()}
-              className="bg-secondary rounded-full px-4 py-2 text-white text-[20px] font-bold hover:bg-gradient-to-r from-red-500 to-purple-500"
+              className="bg-secondary rounded-full px-4 lg:py-2 p-1 overflow-hidden lg:text-lg text-base font-bold hover:bg-gradient-to-r from-red-500 to-purple-500"
             >
               Learn More
             </Link>
           </div>
         </div>
+        {/* Image */}
+        <div className="lg:w-80 lg:h-80 md:w-56 md:h-56 w-40 h-40 mask mask-circle">
+          <img
+            src={carousel1}
+            className="w-full h-full object-cover"
+            alt="Abstract art of outlines of people filled in with colorful patterns representing individuals' uniqueness."
+          />
+        </div>
+        {/* Button for small and medium screens */}
+        <div className="lg:hidden w-full text-center">
+          <Link
+            onClick={() => scroll()}
+            className="bg-secondary rounded-full px-4 py-2 text-sm md:text-base font-bold hover:bg-gradient-to-r from-red-500 to-purple-500"
+          >
+            Learn More
+          </Link>
+        </div>
       </div>
     </div>
-  )
+  );
 }

--- a/src/components/Slide2.jsx
+++ b/src/components/Slide2.jsx
@@ -1,0 +1,40 @@
+// LIBRARY IMPORTS
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+// LOCAL IMPORTS
+import carousel2 from '../assets/images/home/carousel2.png';
+
+export default function Slide2({ scroll }) {
+  return (
+    <div className="carousel-item relative w-full scroll-smooth">
+      <div className="hero  h-[30rem] lg:h-[35rem] max-h-[100%] bg-primary">
+        <div className="hero-content flex-col lg:flex-row-reverse">
+          <img
+            src={carousel2}
+            className="max-w-sm  mx-auto h-[12rem] w-[9rem] lg:w-[20%] lg:h-[25%] shadow-2xl"
+          />
+          <div className="h-[305px] w-[100%] md:justify-start  justify-center lg:text-start text-center lg:w-[50rem] sm:h-fit">
+            <p className="lg:text-5xl py-1 text-white font-bold text-[25px] lg:text-[20px]]">
+              Your Story Matters
+            </p>
+            <p className="lg:py-3 py-1 text-white text-[16px] w-[97%] lg:text-2xl lg:w-[85%]">
+              Your journey is unique, and every step is a victory.{' '}
+            </p>
+            <p className="lg:py-3 py-1 text-white text-[16px] w-[97%] lg:text-2xl lg:w-[85%]">
+              Inspire your network with your Unmatched story.{' '}
+            </p>
+            <div className="mt-[2rem]">
+              <Link
+                onClick={() => scroll()}
+                className="bg-secondary rounded-full px-4 lg:py-2 p-1 overflow-hidden text-white lg:text-[20px] text-[15px] font-bold hover:bg-gradient-to-r from-red-500 to-purple-500"
+              >
+                Learn More
+              </Link>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/Slide2.jsx
+++ b/src/components/Slide2.jsx
@@ -7,34 +7,46 @@ import carousel2 from '../assets/images/home/carousel2.png';
 
 export default function Slide2({ scroll }) {
   return (
-    <div className="carousel-item relative w-full scroll-smooth">
-      <div className="hero  h-[30rem] lg:h-[35rem] max-h-[100%] bg-primary">
-        <div className="hero-content flex-col lg:flex-row-reverse">
-          <img
-            src={carousel2}
-            className="max-w-sm  mx-auto h-[12rem] w-[9rem] lg:w-[20%] lg:h-[25%] shadow-2xl"
-          />
-          <div className="h-[305px] w-[100%] md:justify-start  justify-center lg:text-start text-center lg:w-[50rem] sm:h-fit">
-            <p className="lg:text-5xl py-1 text-white font-bold text-[25px] lg:text-[20px]]">
-              Your Story Matters
-            </p>
-            <p className="lg:py-3 py-1 text-white text-[16px] w-[97%] lg:text-2xl lg:w-[85%]">
-              Your journey is unique, and every step is a victory.{' '}
-            </p>
-            <p className="lg:py-3 py-1 text-white text-[16px] w-[97%] lg:text-2xl lg:w-[85%]">
-              Inspire your network with your Unmatched story.{' '}
-            </p>
-            <div className="mt-[2rem]">
-              <Link
-                onClick={() => scroll()}
-                className="bg-secondary rounded-full px-4 lg:py-2 p-1 overflow-hidden text-white lg:text-[20px] text-[15px] font-bold hover:bg-gradient-to-r from-red-500 to-purple-500"
-              >
-                Learn More
-              </Link>
-            </div>
+    <div className="relative flex items-center justify-center h-full bg-primary">
+      <div className="md:w-[70%] w-[90%] mx-auto flex flex-col lg:flex-row justify-center items-center xl:gap-16 lg:gap-10 gap-4 text-white">
+        <div className="flex flex-col gap-0 md:gap-5 justify-center text-center lg:text-left">
+          <h1 className="text-3xl md:text-4xl lg:text-5xl font-bold">
+            Your Story Matters
+          </h1>
+          <div className="xl:text-2xl lg:text-xl lg:w-[85%] flex flex-col items-center justify-center gap-1">
+            <p>Your journey is unique, and every step is a victory.</p>
+            <p>Inspire your network with your Unmatched story.</p>
           </div>
+          {/* Button for large screens */}
+          <div className="hidden lg:block">
+            <Link
+              onClick={() => scroll()}
+              className="bg-secondary rounded-full px-4 lg:py-2 p-1 overflow-hidden lg:text-lg text-base font-bold hover:bg-gradient-to-r from-red-500 to-purple-500"
+            >
+              Learn More
+            </Link>
+          </div>
+        </div>
+        {/* Image */}
+        <div className="">
+          <div className="w-36 lg:w-52 xl:w-60 h-auto">
+            <img
+              src={carousel2}
+              className="w-full h-full object-cover"
+              alt="Card component with user icon and text: Your Name Here, STEM Industry Leader"
+            />
+          </div>
+        </div>
+        {/* Button for small and medium screens */}
+        <div className="lg:hidden w-full text-center">
+          <Link
+            onClick={() => scroll()}
+            className="bg-secondary rounded-full px-4 py-2 text-sm md:text-base font-bold hover:bg-gradient-to-r from-red-500 to-purple-500"
+          >
+            Learn More
+          </Link>
         </div>
       </div>
     </div>
-  )
+  );
 }

--- a/src/components/Slide3.jsx
+++ b/src/components/Slide3.jsx
@@ -7,37 +7,50 @@ import carousel3 from '../assets/images/home/carousel3.png';
 
 export default function Slide3({ scroll }) {
   return (
-    <div className="carousel-item relative w-full scroll-smooth">
-      <div className="hero  h-[30rem] lg:h-[35rem] max-h-[100%] bg-primary">
-        <div className="hero-content flex-col lg:flex-row-reverse">
+    <div className="relative flex items-center justify-center h-full bg-primary">
+      <div className="md:w-[70%] w-[90%] mx-auto flex flex-col lg:flex-row justify-center items-center xl:gap-16 lg:gap-10 gap-4 text-white">
+        <div className="flex flex-col gap-0 md:gap-5 justify-center text-center lg:text-left">
+          <h1 className="text-2xl md:text-4xl lg:text-5xl font-bold">
+            Connect with STEM Voices
+          </h1>
+          <div className="xl:text-2xl lg:text-xl lg:w-[85%] flex flex-col items-center justify-center gap-4">
+            <p>
+              Uncover stories of STEM leaders who’ve overcome imposter syndrome
+              and fostered a more inclusive and empowering STEM community.
+            </p>
+            <p>
+              Find strength and inspiration in their experiences as you navigate
+              your own STEM path.
+            </p>
+          </div>
+          {/* Button for large screens */}
+          <div className="hidden lg:block">
+            <Link
+              onClick={() => scroll()}
+              className="bg-secondary rounded-full px-4 lg:py-2 p-1 overflow-hidden lg:text-lg text-base font-bold hover:bg-gradient-to-r from-red-500 to-purple-500"
+            >
+              Learn More
+            </Link>
+          </div>
+        </div>
+        {/* Image */}
+        <div className="xl:w-[80%] lg:w-full lg:h-72 w-40 h-40">
           <img
             src={carousel3}
-            className="max-w-sm  mx-auto w-[30%] h-[5rem] lg:h-[20rem] shadow-2xl"
+            className="w-full h-full object-cover rounded-md"
+            alt=""
           />
-          <div className="h-[305px] w-[80%] lg:w-[50rem] sm:h-fit md:justify-start lg:text-start  justify-center text-center ">
-            <p className="lg:text-5xl py-1 text-white font-bold text-[25px] lg:text-[20px]]">
-              Connect with STEM Voices
-            </p>
-            <p className="lg:py-1 py-0 text-white text-[16px] w-[97%] lg:text-[21px] lg:w-[85%]">
-              Uncover stories of STEM leaders who’ve overcome imposter
-              syndrome and fostered a more inclusive STEM community.{' '}
-            </p>
-            <p className="lg:py-1 py-0 text-white text-[16px] w-[97%] lg:text-[21px] lg:w-[85%]">
-              {' '}
-              Find strength and inspiration as you navigate your own STEM
-              path.{' '}
-            </p>
-            <div className="mt-[2rem]">
-              <Link
-                onClick={() => scroll()}
-                className="bg-secondary rounded-full px-4 lg:py-2 p-1 overflow-hidden text-white lg:text-[20px] text-[15px] font-bold hover:bg-gradient-to-r from-red-500 to-purple-500"
-              >
-                Learn More
-              </Link>
-            </div>
-          </div>
+        </div>
+        {/* Button for small and medium screens */}
+        <div className="lg:hidden w-full text-center">
+          <Link
+            onClick={() => scroll()}
+            className="text-sm md:text-base bg-secondary rounded-full px-3 py-1 md:px-4 md:py-2 font-bold hover:bg-gradient-to-r from-red-500 to-purple-500"
+          >
+            Learn More
+          </Link>
         </div>
       </div>
     </div>
-  )
+  );
 }

--- a/src/components/Slide3.jsx
+++ b/src/components/Slide3.jsx
@@ -1,0 +1,43 @@
+// LIBRARY IMPORTS
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+// LOCAL IMPORTS
+import carousel3 from '../assets/images/home/carousel3.png';
+
+export default function Slide3({ scroll }) {
+  return (
+    <div className="carousel-item relative w-full scroll-smooth">
+      <div className="hero  h-[30rem] lg:h-[35rem] max-h-[100%] bg-primary">
+        <div className="hero-content flex-col lg:flex-row-reverse">
+          <img
+            src={carousel3}
+            className="max-w-sm  mx-auto w-[30%] h-[5rem] lg:h-[20rem] shadow-2xl"
+          />
+          <div className="h-[305px] w-[80%] lg:w-[50rem] sm:h-fit md:justify-start lg:text-start  justify-center text-center ">
+            <p className="lg:text-5xl py-1 text-white font-bold text-[25px] lg:text-[20px]]">
+              Connect with STEM Voices
+            </p>
+            <p className="lg:py-1 py-0 text-white text-[16px] w-[97%] lg:text-[21px] lg:w-[85%]">
+              Uncover stories of STEM leaders who’ve overcome imposter
+              syndrome and fostered a more inclusive STEM community.{' '}
+            </p>
+            <p className="lg:py-1 py-0 text-white text-[16px] w-[97%] lg:text-[21px] lg:w-[85%]">
+              {' '}
+              Find strength and inspiration as you navigate your own STEM
+              path.{' '}
+            </p>
+            <div className="mt-[2rem]">
+              <Link
+                onClick={() => scroll()}
+                className="bg-secondary rounded-full px-4 lg:py-2 p-1 overflow-hidden text-white lg:text-[20px] text-[15px] font-bold hover:bg-gradient-to-r from-red-500 to-purple-500"
+              >
+                Learn More
+              </Link>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/StoryMission.jsx
+++ b/src/components/StoryMission.jsx
@@ -1,21 +1,12 @@
 // LIBRARY IMPORTS
-import { useRef } from 'react';
 import React from 'react';
 
 // LOCAL IMPORTS
 import story from '../assets/images/home/story.jpeg';
 import mission from '../assets/images/home/mission.jpeg';
-import HeroCarousel from './HeroCarousel';
 
-
-export default function StoryMission() {
-  const firstItem = useRef(null);
-  const scroll = () =>{
-    firstItem.current.scrollIntoView();
-  }
+export default function StoryMission({ firstItem }) {
   return (
-    <>
-    <HeroCarousel scroll = {scroll}/>
     <div className="py-16 lg:py-24 px-6 lg:px-24 w-[90%] object-center m-auto mt-[4rem]">
       <div className="container mx-auto px-6 lg:px-8" ref={firstItem}>
         <div className="flex flex-wrap justify-between lg:items-start items-center gap-14 mb-[10rem]">
@@ -33,7 +24,7 @@ export default function StoryMission() {
           <div className="flex-1">
             <h2 className="lg:text-3xl text-2xl font-bold text-primary">Our Mission</h2>
             <p className="mt-5  text:21px md:text-[22px] lg:text-[23px] text-primary">
-              We’re dedicated to fostering confidence, motivation, and success in the next generation of STEM leaders. 
+              We’re dedicated to fostering confidence, motivation, and success in the next generation of STEM leaders.
             </p>
             <p className="mt-5  text:21px md:text-[22px] lg:text-[23px] text-primary">
             Access relatable and inspiring narratives about STEM professionals who’ve triumphed over imposter syndrome and discover how you can too.
@@ -45,6 +36,5 @@ export default function StoryMission() {
         </div>
       </div>
     </div>
-    </>
   )
 }

--- a/src/components/StoryMission.jsx
+++ b/src/components/StoryMission.jsx
@@ -7,8 +7,8 @@ import mission from '../assets/images/home/mission.jpeg';
 
 export default function StoryMission({ firstItem }) {
   return (
-    <div className="py-16 lg:py-24 px-6 lg:px-24 w-[90%] object-center m-auto mt-[4rem]">
-      <div className="container mx-auto px-6 lg:px-8" ref={firstItem}>
+    <div className="py-16 lg:py-24 px-6 lg:px-24 w-[90%] object-center m-auto mt-[4rem]" ref={firstItem}>
+      <div className="container mx-auto px-6 lg:px-8" >
         <div className="flex flex-wrap justify-between lg:items-start items-center gap-14 mb-[10rem]">
           <div>
             <img

--- a/src/components/StoryMission.jsx
+++ b/src/components/StoryMission.jsx
@@ -7,12 +7,15 @@ import mission from '../assets/images/home/mission.jpeg';
 
 export default function StoryMission({ firstItem }) {
   return (
-    <div className="py-16 lg:py-24 px-6 lg:px-24 w-[90%] object-center m-auto mt-[4rem]" ref={firstItem}>
-      <div className="container mx-auto px-6 lg:px-8" >
-        <div className="flex flex-wrap justify-between lg:items-start items-center gap-14 mb-[10rem]">
-          <div>
+    <div
+      className="py-16 xl:p-24 w-[90%] object-center m-auto mt-[4rem]"
+      ref={firstItem}
+    >
+      <div className="container mx-auto px-6 lg:px-8">
+        <div className="flex flex-col-reverse lg:flex-row justify-between lg:items-start items-center gap-14 md:mb-[10rem]">
+          <div className="flex-1">
             <img
-              className="rounded-2xl  border lg:w-[400px] md:w-[300px] max-w-md mx-auto w-[280px] lg:max-w-lg"
+              className="rounded-2xl md:h-80 md:w-screen object-cover"
               src={story}
               alt="Our Story"
             />
@@ -28,7 +31,7 @@ export default function StoryMission({ firstItem }) {
             </p>
           </div>
         </div>
-        <div className="flex flex-wrap justify-between  lg:items-start items-center  gap-14 mt-14 lg:mt-28 mb-[4rem]">
+        <div className="flex flex-col lg:flex-row justify-between lg:items-start items-center gap-14 mt-14 lg:mt-28 mb-[4rem]">
           <div className="flex-1">
             <h2 className="lg:text-3xl text-2xl font-bold text-primary">
               Our Mission
@@ -45,7 +48,7 @@ export default function StoryMission({ firstItem }) {
           </div>
           <div className="flex-1">
             <img
-              className="rounded-2xl border max-w-md mx-auto w-[280px] lg:w-[400px] lg:max-w-lg"
+              className="rounded-2xl md:h-80 md:w-screen object-cover"
               src={mission}
               alt="Our Mission"
             />

--- a/src/components/StoryMission.jsx
+++ b/src/components/StoryMission.jsx
@@ -7,52 +7,47 @@ import mission from '../assets/images/home/mission.jpeg';
 
 export default function StoryMission({ firstItem }) {
   return (
-    <div
-      className="py-16 xl:p-24 w-[90%] object-center m-auto mt-[4rem]"
-      ref={firstItem}
-    >
-      <div className="container mx-auto px-6 lg:px-8">
-        <div className="flex flex-col-reverse lg:flex-row justify-between lg:items-start items-center gap-14 md:mb-[10rem]">
-          <div className="flex-1">
-            <img
-              className="rounded-2xl md:h-80 md:w-screen object-cover"
-              src={story}
-              alt="Our Story"
-            />
-          </div>
-          <div className="flex-1">
-            <h2 className="lg:text-3xl text-2xl font-bold text-primary">
-              Our Story
-            </h2>
-            <p className="mt-5 text:21px md:text-[22px] lg:text-[23px] text-primary ">
-              Unmatched started in 2023 with one purpose: to empower
-              underrepresented STEM (science, technology, engineering, and math)
-              students to overcome imposter syndrome and achieve their dreams.
-            </p>
-          </div>
+    <div className="flex flex-col gap-10 mb-20" ref={firstItem}>
+      <div className="flex flex-col-reverse lg:flex-row justify-between lg:items-start items-center gap-14">
+        <div className="flex-1">
+          <img
+            className="rounded-2xl md:h-80 md:w-screen object-cover"
+            src={story}
+            alt="Our Story"
+          />
         </div>
-        <div className="flex flex-col lg:flex-row justify-between lg:items-start items-center gap-14 mt-14 lg:mt-28 mb-[4rem]">
-          <div className="flex-1">
-            <h2 className="lg:text-3xl text-2xl font-bold text-primary">
-              Our Mission
-            </h2>
-            <p className="mt-5  text:21px md:text-[22px] lg:text-[23px] text-primary">
-              We’re dedicated to fostering confidence, motivation, and success
-              in the next generation of STEM leaders.
-            </p>
-            <p className="mt-5  text:21px md:text-[22px] lg:text-[23px] text-primary">
-              Access relatable and inspiring narratives about STEM professionals
-              who’ve triumphed over imposter syndrome and discover how you can
-              too.
-            </p>
-          </div>
-          <div className="flex-1">
-            <img
-              className="rounded-2xl md:h-80 md:w-screen object-cover"
-              src={mission}
-              alt="Our Mission"
-            />
-          </div>
+        <div className="flex-1">
+          <h2 className="lg:text-3xl text-2xl font-bold text-primary">
+            Our Story
+          </h2>
+          <p className="mt-5 text:21px md:text-[22px] lg:text-[23px] text-primary ">
+            Unmatched started in 2023 with one purpose: to empower
+            underrepresented STEM (science, technology, engineering, and math)
+            students to overcome imposter syndrome and achieve their dreams.
+          </p>
+        </div>
+      </div>
+      <div className="flex flex-col lg:flex-row justify-between lg:items-start items-center gap-14 mt-14 lg:mt-28 mb-[4rem]">
+        <div className="flex-1">
+          <h2 className="lg:text-3xl text-2xl font-bold text-primary">
+            Our Mission
+          </h2>
+          <p className="mt-5  text:21px md:text-[22px] lg:text-[23px] text-primary">
+            We’re dedicated to fostering confidence, motivation, and success in
+            the next generation of STEM leaders.
+          </p>
+          <p className="mt-5  text:21px md:text-[22px] lg:text-[23px] text-primary">
+            Access relatable and inspiring narratives about STEM professionals
+            who’ve triumphed over imposter syndrome and discover how you can
+            too.
+          </p>
+        </div>
+        <div className="flex-1">
+          <img
+            className="rounded-2xl md:h-80 md:w-screen object-cover"
+            src={mission}
+            alt="Our Mission"
+          />
         </div>
       </div>
     </div>

--- a/src/views/Home.jsx
+++ b/src/views/Home.jsx
@@ -1,5 +1,5 @@
 // LIBRARY IMPORTS
-import React from 'react';
+import React, { useRef } from 'react';
 import { Link } from 'react-router-dom';
 
 // LOCAL IMPORTS
@@ -8,10 +8,12 @@ import StoryMission from '../components/StoryMission.jsx';
 import SingleCard from '../components/SingleCard.jsx';
 
 export function Home({ fullDataSet, changeVoicesColor,resetData}) {
+  // HANDLERS & CONSTANTS
   const limitData = []
   for(let i = 0; i<3; i++){
     limitData.push(fullDataSet[i])
   };
+
   const limitDataCard = limitData.map(data => {
     return (
       <SingleCard
@@ -23,14 +25,21 @@ export function Home({ fullDataSet, changeVoicesColor,resetData}) {
       />
     );
   });
+
   const handleVoiceIconClick = () => {
     resetData()
     changeVoicesColor();
   };
+
+  const firstItem = useRef(null);
+  const scroll = () =>{
+    firstItem.current.scrollIntoView();
+  }
+
   return (
     <div className="bg-base-100">
-   
-      <StoryMission />
+      <HeroCarousel scroll = {scroll} />
+      <StoryMission firstItem = {firstItem} />
       <div className="max-w-[1200px] xl:mx-auto md:mx-8 sm:mx-8">
         <div className="lg:text-3xl text-2xl font-bold text-center text-primary px-4">
             Explore Unmatched's Empowering Voices
@@ -40,7 +49,7 @@ export function Home({ fullDataSet, changeVoicesColor,resetData}) {
           <div className="grid lg:grid-cols-3 md:grid-cols-2 md:m-auto sm:grid-cols-1 gap-12 place-items-center m-auto">
         {limitDataCard}
         </div>
-        
+
         </div>
         <Link
               to="/professionals"
@@ -49,7 +58,7 @@ export function Home({ fullDataSet, changeVoicesColor,resetData}) {
              Unmatched Voices
             </Link>
         </div>
-       
+
       </div>
     </div>
   )

--- a/src/views/Home.jsx
+++ b/src/views/Home.jsx
@@ -38,7 +38,7 @@ export function Home({ fullDataSet, changeVoicesColor, resetData }) {
   };
 
   return (
-    <div className="bg-base-100">
+    <div>
       <HeroCarousel scroll={scroll} />
       <StoryMission firstItem={firstItem} />
       <div className="max-w-[1200px] xl:mx-auto md:mx-8 sm:mx-8">

--- a/src/views/Home.jsx
+++ b/src/views/Home.jsx
@@ -40,24 +40,27 @@ export function Home({ fullDataSet, changeVoicesColor, resetData }) {
   return (
     <div>
       <HeroCarousel scroll={scroll} />
-      <StoryMission firstItem={firstItem} />
-      <div className="max-w-[1200px] xl:mx-auto md:mx-8 sm:mx-8">
-        <div className="lg:text-3xl text-2xl font-bold text-center text-primary px-4">
-          Explore Unmatched's Empowering Voices
-        </div>
-        <div className="max-w-[1200px] xl:mx-auto md:mx-28 sm:mx-8">
-          <div className="w-full py-[2rem] md:py-[4rem] px-4">
-            <div className="grid lg:grid-cols-3 md:grid-cols-2 md:m-auto sm:grid-cols-1 gap-12 place-items-center m-auto">
-              {limitDataCard}
+      <div className="py-16 xl:p-24 w-[90%] object-center m-auto mt-[4rem]">
+        <div className="container mx-auto px-6 lg:px-8 ">
+          <StoryMission firstItem={firstItem} />
+          <section>
+            <div className="text-center lg:text-left">
+              <h2 className="lg:text-3xl text-2xl font-bold pb-5">
+                Explore Unmatched's Empowering Voices
+              </h2>
+              <div className="mt-7 flex flex-col flex-wrap md:flex-row lg:justify-between md:justify-between justify-center items-center mb-20 gap-y-10 md:mx-16 lg:mx-auto">
+                {limitDataCard}
+              </div>
             </div>
-          </div>
-          <Link
-            to="/professionals"
-            className="px-4 md:float-right py-2 justify-center mr-5 rounded-full font-bold bg-red-500 hover:bg-gradient-to-r from-red-500 to-purple-500  text-white mb-12"
-            onClick={handleVoiceIconClick}
-          >
-            Unmatched Voices
-          </Link>
+            <div className="flex justify-center lg:justify-end">
+              <Link
+                to="/professionals"
+                className="px-4 py-2 rounded-full font-bold bg-red-500 hover:bg-gradient-to-r from-red-500 to-purple-500  text-white"
+              >
+                Unmatched Voices
+              </Link>
+            </div>
+          </section>
         </div>
       </div>
     </div>

--- a/src/views/Layout.jsx
+++ b/src/views/Layout.jsx
@@ -7,10 +7,16 @@ import NavBar from '../components/Navbar';
 import logo from '../assets/logo.png';
 import Footer from '../components/Footer';
 
-export function Layout({ChangeAboutIcon, changeVoicesColor,iconClick,resetData,resetTags }) {
+export function Layout({
+  ChangeAboutIcon,
+  changeVoicesColor,
+  iconClick,
+  resetData,
+  resetTags,
+}) {
   return (
     <div className="flex flex-col w-full h-full min-h-screen ">
-      <div className="py-6 mb-12 px-2 md:px-5 w-full fixed bg-white z-40 top-0"> 
+      <div className="py-6 px-2 md:px-5 w-full sticky bg-white z-40 top-0">
         <div className="flex justify-between items-center mx-auto">
           <div className="flex-shrink-0">
             <Link to="/">
@@ -21,14 +27,19 @@ export function Layout({ChangeAboutIcon, changeVoicesColor,iconClick,resetData,r
               />
             </Link>
           </div>
-          <NavBar ChangeAboutIcon= {ChangeAboutIcon} changeVoicesColor= {changeVoicesColor} iconClick={iconClick}
-          resetData={resetData} resetTags={resetTags}/>
+          <NavBar
+            ChangeAboutIcon={ChangeAboutIcon}
+            changeVoicesColor={changeVoicesColor}
+            iconClick={iconClick}
+            resetData={resetData}
+            resetTags={resetTags}
+          />
         </div>
       </div>
-      <main className="flex-1 flex flex-col w-full">
+      <main className="flex flex-col w-full">
         <Outlet />
       </main>
-      <Footer/>
+      <Footer />
     </div>
   );
 }

--- a/src/views/ProfessionalsPage.jsx
+++ b/src/views/ProfessionalsPage.jsx
@@ -13,7 +13,7 @@ export function ProfessionalsPage({
   fullDataSet,
   getFilteredCards,
   changeButtonColor,
-  tags
+  tags,
 }) {
   // SET STATES
   const [clearedSearch, setClearedSearch] = useState(true);
@@ -21,7 +21,7 @@ export function ProfessionalsPage({
   return (
     <div>
       <div className="flex flex-col gap-5 text-center text-primary my-10 mx-auto ">
-        <h1 className="lg:text-4xl md:text-3xl text-2xl font-bold mt-14">
+        <h1 className="lg:text-4xl md:text-3xl text-2xl font-bold">
           You're in good company.
         </h1>
         <div className="md:w-[50%] lg:w-[50%] xl:w-[35%] w-[80%] mx-auto lg:text-xl md:text-lg mb-10">
@@ -36,8 +36,11 @@ export function ProfessionalsPage({
         fullDataSet={fullDataSet}
         setClearedSearch={setClearedSearch}
       />
-      <FilterButtonList getFilteredCards={getFilteredCards} tags={tags}
-                changeButtonColor={changeButtonColor}/>
+      <FilterButtonList
+        getFilteredCards={getFilteredCards}
+        tags={tags}
+        changeButtonColor={changeButtonColor}
+      />
       {clearedSearch ? (
         <Card
           data={data}


### PR DESCRIPTION
## Description
This PR fixes the responsiveness of the home page for tablet and mobile views. Currently, this PR has adjusted responsiveness of the homepage carousel slide 1 ONLY and has adjusted the image on that carousel (which was previously stretched/distorted). This PR also has refactored the components using React's philosophy of separation of concerns to make sure each component is rendered in the most logical place and that no component is too big/unwieldy and is made of smaller components instead (specifically the Hero Component). 
<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

## Related Tickets & Documents
This ticket closes #UM-33
<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->

## Acceptance Criteria
<!-- Put an `x` between the brackets to mark complete (don't add spaces) e.g. -[x] -->
<!-- Include AC from the JIRA ticket https://lemon-zest.atlassian.net/jira/software/projects/UM/boards/2 -->

- [ ] Ensure the homepage adheres to Tailwind CSS breakpoints sm, md, lg breakpoints
- [ ] The homepage layout must adjust content, including the carousel, text blocks, and profile grids, to suit the screen size without compromising functionality or aesthetics.
- [ ] The hero carousel should display correctly on all devices, with navigation arrows and pagination dots remaining interactive and accessible.
- [ ] All text, including headings, paragraphs, and button labels, should maintain readability across devices, with size and spacing adjustments as needed.
- [ ] Navigation elements, such as the menu bar and buttons, should remain functional and easy to interact with, even on smaller screens.
- [ ] On a laptop, display all profiles in a row. On a tablet and on a phone, stack profiles in a single column format.
- [ ] Ensure that all interactive elements, including buttons and links, are easily tappable on touchscreen devices with appropriate size and spacing.

## What type of PR is this? (check all applicable)
<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|     | :sparkles: New feature     |
| ✓ | 🎨 Style                   |
|  ✓ | :hammer: Refactoring       |
|     | 🔥 Performance Improvements|
|     | :bug: Bug fix              |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |


## Mobile & Desktop Screenshots/Recordings

**BEFORE** Desktop:
<img src="https://github.com/cherryontech/unmatched/assets/115492619/a450d050-fcd1-4734-a9c2-ec8578a6c4d5" width="400">
**AFTER** Desktop:
<img src="https://github.com/cherryontech/unmatched/assets/115492619/96d0eef9-0c86-4fa7-9b69-d090901538b3" width="400">

**BEFORE** Tablet:
<img src="https://github.com/cherryontech/unmatched/assets/115492619/a4dc8122-abc7-4e4c-bc77-3e0651b31beb" width="300">
**AFTER** Tablet:
<img src="https://github.com/cherryontech/unmatched/assets/115492619/c8190068-7dae-43ae-bd9b-99a9132d22df" width="300">

**BEFORE** Mobile:
<img src="https://github.com/cherryontech/unmatched/assets/115492619/ebd71688-dc62-4dd1-9b2e-1e4d628460c7" width="250">
**AFTER** Mobile:
<img src="https://github.com/cherryontech/unmatched/assets/115492619/5751507b-4e9c-493e-8fc6-932fa632609f" width="250">

<!-- Visual changes require screenshots -->

## What I learned
Looking at the whole home page as one component and trying to address responsiveness is overwhelming and ineffective. Instead I broke carousel slide 1 off into a separate component and started looking at the responsive of each element in that component, starting with the hero container div, moving to the image size, and then looking at text size and positioning. Also Tailwind properties like `object-fit` and `object-cover` are needed to maintain an image's proportions/ratios

## Testing steps
1. Switch to this branch with the following command: `git switch style/UM-33-home-responsive`
2. Run the following scripts: `npm run dev` to start Vite's dev build & `npm run tailwind` to start the Tailwind CSS build
3. View the app in browser (the `npm run dev` script will return the url you can see the app at)
4. Inspect the home page in relation to the Figma design (using Chrome Dev Tools or similar to view different screen sizes). NOTE: use the iPad Air option for tablet vs iPad Pro as the iPad Pro defaults to the 'large' breakpoint


## Added to documentation?
<!-- Put an `✓` for the applicable box: -->
|     | Type                       |
| --- | -------------------------- |
|     | 📜 README.md    |
| ✓  | 🙅 no documentation needed    |


## What gif best describes this PR or how it makes you feel?
  ![shimmy](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExeTZqa2szcnh0bXV1dmdvdnBtNDM1a25kMWZvZnloM3A4dGw4NHI4ayZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/nNxT5qXR02FOM/giphy.gif) 
<!-- 
  to easily include a gif, go to giphy.com, copy the gif link (must be a gif, not a clip/video),
  and then insert it following this format:
  ![gif name](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExeTZqa2szcnh0bXV1dmdvdnBtNDM1a25kMWZvZnloM3A4dGw4NHI4ayZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/nNxT5qXR02FOM/giphy.gif) 
  the name you choose is arbitrary as it won't show up,
  but be sure to include the exclamation mark, brackets, and parentheses
-->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
